### PR TITLE
Add support for Python 3.4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+1.0 (unreleased)
+================
+
+- Add support for Python 3.4. This breaks with Python 2.6 and before.
+
 1.0b3 (2011-12-14)
 ==================
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include mr *.*
+include *.txt
+global-exclude *pyc 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2006 Zope Corporation and Contributors.
+# Copyright (c) 2006 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -16,47 +16,163 @@
 Simply run this script in a directory containing a buildout.cfg.
 The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
-
-$Id: bootstrap.py 85041 2008-03-31 15:57:30Z andreasjung $
 """
 
-import os, shutil, sys, tempfile, urllib2
+import os
+import shutil
+import sys
+import tempfile
+
+from optparse import OptionParser
 
 tmpeggs = tempfile.mkdtemp()
 
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep 
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("-v", "--version", help="use a specific zc.buildout version")
+
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+
+
+options, args = parser.parse_args()
+
+######################################################################
+# load/install setuptools
+
 try:
-    import pkg_resources
+    if options.allow_site_packages:
+        import setuptools
+        import pkg_resources
+    from urllib.request import urlopen
 except ImportError:
-    ez = {}
-    exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
-                         ).read() in ez
-    ez['use_setuptools'](to_dir=tmpeggs, download_delay=0)
+    from urllib2 import urlopen
 
-    import pkg_resources
+ez = {}
+exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
-if sys.platform == 'win32':
-    def quote(c):
-        if ' ' in c:
-            return '"%s"' % c # work around spawn lamosity on windows
-        else:
-            return c
-else:
-    def quote (c):
-        return c
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions 
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'. 
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
 
-cmd = 'from setuptools.command.easy_install import main; main()'
-ws  = pkg_resources.working_set
-assert os.spawnle(
-    os.P_WAIT, sys.executable, quote (sys.executable),
-    '-c', quote (cmd), '-mqNxd', quote (tmpeggs), 'zc.buildout',
-    dict(os.environ,
-         PYTHONPATH=
-         ws.find(pkg_resources.Requirement.parse('setuptools')).location
-         ),
-    ) == 0
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+cmd = [sys.executable, '-c',
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+requirement = 'zc.buildout'
+version = options.version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        for part in parsed_version:
+            if (part[:1] == '*') and (part not in _final_parts):
+                return False
+        return True
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
 
 ws.add_entry(tmpeggs)
-ws.require('zc.buildout')
+ws.require(requirement)
 import zc.buildout.buildout
-zc.buildout.buildout.main(sys.argv[1:] + ['bootstrap'])
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
+zc.buildout.buildout.main(args)
 shutil.rmtree(tmpeggs)

--- a/mr/scripty/README.txt
+++ b/mr/scripty/README.txt
@@ -19,13 +19,13 @@ is available for replacement in other buildout parts. What is returned is
 always converted to a string.
 
 The one special exception to the above is the ``init`` option, which
-is not stored.  Utilising this option allows you to reduce the need for 
-multiple functions that may do similar jobs, remove the need for a dummy 
+is not stored.  Utilising this option allows you to reduce the need for
+multiple functions that may do similar jobs, remove the need for a dummy
 option in order to execute arbitrary code (and other uses), like so::
-    
+
     [myscripts]
     recipe = mr.scripty
-    init = 
+    init =
         ... import math
         ... self.options['pi'] = str(math.pi)
         ... self.options['e'] = str(math.e)
@@ -84,36 +84,35 @@ be used inside haproxy::
     ...   ... for line in self.buildout['varnish']['backends'].splitlines():
     ...   ...    if ':' not in line:
     ...   ...      continue
-    ...   ...    host,dest = line.split(':')
+    ...   ...    host, dest = line.strip().split(':')
     ...   ...    host = host.split('.')[0]
-    ...   ...    res += "acl %s url_sub VirtualHostRoot/%s\\n" % (dest,host)
+    ...   ...    res += "acl {} url_sub VirtualHostRoot/{}\\n".format(host, dest)
     ...   ... return res
     ... repeat =
-    ...   ... opt_repeatx = int(self.options['repeatx'])
+    ...   ... opt_repeatx = int('10')
     ...   ... fun_repeatx = self.repeatx()
     ...   ... return '\\n'.join(["this is line %s"%i for i in range(1,opt_repeatx+1)])
     ... repeatx = return '10'
     ...
     ... [echobackends]
     ... recipe = mr.scripty
-    ... install = print self.buildout['scripty']['backends']; return []
+    ... install = print(self.buildout['scripty']['backends']); return []
     ...
     ... [echorepeat]
     ... recipe = mr.scripty
     ... install =
     ...   ... script = self.buildout['scripty']
-    ...   ... print script['repeat']
+    ...   ... print(script['repeat'])
     ...   ... return []
     ... """)
 
 Running the buildout gives us::
 
-    >>> print 'start', system(buildout) 
-    start...
+    >>> print(system(buildout))
+    Installing scripty.
     Installing echobackends.
     acl host url_sub VirtualHostRoot/255.255.255.1
     acl host2 url_sub VirtualHostRoot/125.125.125.1
-    <BLANKLINE>
     Installing echorepeat.
     this is line 1
     this is line 2
@@ -124,8 +123,7 @@ Running the buildout gives us::
     this is line 7
     this is line 8
     this is line 9
-    this is line 10
-    <BLANKLINE>
+    this is line 10...
 
 From this example you'll notice several things. Options that are part of a
 `mr.scripty` part are turned into methods of the part instance and can call
@@ -157,7 +155,7 @@ section using arbitrary code.  In the example above, this will result in all
 of the options under ``[ports_base]`` being processed to add the ``OFFSET``
 value to the port.  The end result is that other sections of buildout can now
 reference ``${ports:instance1}`` and ``${ports:instance2}``, which will have
-values of 9101 and 9102 respectively. 
+values of 9101 and 9102 respectively.
 
 Different download links for certain architectures
 --------------------------------------------------
@@ -192,7 +190,7 @@ the first one that can be found on the system.  In this particular example,
 we look through a list of potential JDK directories, as the location will
 differ across Linux distributions, in order to install an egg that depends
 on having a Java SDK install available::
-     
+
     [buildout]
     parts =
         ...
@@ -200,11 +198,11 @@ on having a Java SDK install available::
 
     [scripty]
     recipe = mr.scripty
-    JAVA_PATHS = 
+    JAVA_PATHS =
         /usr/lib/jvm/java-6-openjdk
         /etc/alternatives/java_sdk
         ${buildout:directory}
-    java = 
+    java =
         ... import os
         ... paths = self.JAVA_PATHS.split('\n')
         ... exists = [os.path.exists(path) for path in paths]

--- a/mr/scripty/__init__.py
+++ b/mr/scripty/__init__.py
@@ -25,7 +25,7 @@ class Recipe(object):
                     line = line[4:]
                 if indent:
                     newbody += "  "
-                newbody += line +'\n'
+                newbody += line + '\n'
                 if line.startswith('"""'):
                     indent = not indent
 
@@ -36,14 +36,15 @@ class Recipe(object):
                 pass
 
         for function, body in options.items():
-            if function in ['recipe','install','update']:
+            if function in ['recipe', 'install', 'update']:
                 continue
             if function.startswith('_'):
                 continue
             if function == function.upper():
                 continue
             f = getattr(self, function)
-            #result = _LazyString(f) #LazyStrings don't work for $ substitions
+            # LazyStrings don't work for $ substitions
+            # result = _LazyString(f)
             result = f()
             if function in ['init']:
                 continue
@@ -57,7 +58,7 @@ class Recipe(object):
     def install(self):
         """Installer"""
         # XXX Implement recipe functionality here
-        
+
         # Return files that were created by the recipe. The buildout
         # will remove all returned files upon reinstall.
         return tuple()
@@ -66,16 +67,19 @@ class Recipe(object):
         """Updater"""
         pass
 
+
 class Debug(Recipe):
     def __init__(self, buildout, name, options):
         Recipe.__init__(self, buildout, name, options, debug=True)
 
 
 class LazyString(str):
+
     def __init__(self, func, name, debug):
         self.func = func
         self.name = name
         self.debug = debug
+
     def __new__(cls, func, *args):
         return str.__new__(cls, "This is not the string you are looking for")
 
@@ -84,22 +88,25 @@ class LazyString(str):
         if not hasattr(self, '__evaluated__'):
             self.__evaluated__ = str(self.func())
             if self.debug:
-                print "DEBUG: %s=%s" %(self.name, self.__evaluated__)
+                print "DEBUG: %s=%s" % (self.name, self.__evaluated__)
         return self.__evaluated__
 
     def __str__(self):
         return self.value
+
     def __repr__(self):
         return self.value
+
 
 class _LazyString(str):
     """Class for strings created by a function call.
 
-    The proxy implementation attempts to be as complete as possible, so that
-    the lazy objects should mostly work as expected, for example for sorting.
-    Shamelessly stolen from speaklater, but changed to make it subclass str due to buildout instance check
+    The proxy implementation attempts to be as complete as possible,
+    so that the lazy objects should mostly work as expected, for
+    example for sorting.  Shamelessly stolen from speaklater, but
+    changed to make it subclass str due to buildout instance check
     """
-    #__slots__ = ('_func', '_args', '_kwargs')
+    # __slots__ = ('_func', '_args', '_kwargs')
 
     def __new__(cls, func, *args):
         return str.__new__(cls, "This is not the string you are looking for")
@@ -193,4 +200,3 @@ class _LazyString(str):
             return 'l' + repr(self.value)
         except Exception:
             return '<%s broken>' % self.__class__.__name__
-

--- a/mr/scripty/__init__.py
+++ b/mr/scripty/__init__.py
@@ -29,8 +29,8 @@ class Recipe(object):
                 if line.startswith('"""'):
                     indent = not indent
 
-            exec newbody in globals(), locals()
-            f = types.MethodType(eval(function), self, Recipe)
+            exec(newbody, globals(), locals())
+            f = types.MethodType(eval(function), self)
             setattr(self, function, f)
             if function == 'install':
                 pass
@@ -69,6 +69,7 @@ class Recipe(object):
 
 
 class Debug(Recipe):
+
     def __init__(self, buildout, name, options):
         Recipe.__init__(self, buildout, name, options, debug=True)
 
@@ -88,7 +89,7 @@ class LazyString(str):
         if not hasattr(self, '__evaluated__'):
             self.__evaluated__ = str(self.func())
             if self.debug:
-                print "DEBUG: %s=%s" % (self.name, self.__evaluated__)
+                print("DEBUG: %s=%s" % (self.name, self.__evaluated__))
         return self.__evaluated__
 
     def __str__(self):

--- a/mr/scripty/tests/test_docs.py
+++ b/mr/scripty/tests/test_docs.py
@@ -10,9 +10,11 @@ import zc.buildout.testing
 
 from zope.testing import doctest, renormalizing
 
-optionflags =  (doctest.ELLIPSIS |
-                doctest.NORMALIZE_WHITESPACE |
-                doctest.REPORT_ONLY_FIRST_FAILURE)
+
+OPTIONFLAGS = (doctest.ELLIPSIS |
+               doctest.NORMALIZE_WHITESPACE |
+               doctest.REPORT_ONLY_FIRST_FAILURE)
+
 
 def setUp(test):
     zc.buildout.testing.buildoutSetUp(test)
@@ -21,26 +23,27 @@ def setUp(test):
     zc.buildout.testing.install_develop('mr.scripty', test)
 
     # Install any other recipes that should be available in the tests
-    #zc.buildout.testing.install('collective.recipe.foobar', test)
+    # zc.buildout.testing.install('collective.recipe.foobar', test)
+
 
 def test_suite():
     suite = unittest.TestSuite((
-            doctest.DocFileSuite(
-                '../README.txt',
-                setUp=setUp,
-                tearDown=zc.buildout.testing.buildoutTearDown,
-                optionflags=optionflags,
-                checker=renormalizing.RENormalizing([
-                        # If want to clean up the doctest output you
-                        # can register additional regexp normalizers
-                        # here. The format is a two-tuple with the RE
-                        # as the first item and the replacement as the
-                        # second item, e.g.
-                        # (re.compile('my-[rR]eg[eE]ps'), 'my-regexps')
-                        zc.buildout.testing.normalize_path,
-                        ]),
-                ),
-            ))
+        doctest.DocFileSuite(
+            '../README.txt',
+            setUp=setUp,
+            tearDown=zc.buildout.testing.buildoutTearDown,
+            optionflags=OPTIONFLAGS,
+            checker=renormalizing.RENormalizing([
+                # If want to clean up the doctest output you
+                # can register additional regexp normalizers
+                # here. The format is a two-tuple with the RE
+                # as the first item and the replacement as the
+                # second item, e.g.
+                # (re.compile('my-[rR]eg[eE]ps'), 'my-regexps')
+                zc.buildout.testing.normalize_path,
+            ]),
+        ),
+    ))
     return suite
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,15 @@ long_description = (
     + '\n' +
     read('CHANGES.txt')
     + '\n' +
-   'Download\n'
+    'Download\n'
     '********\n')
 
 entry_point = 'mr.scripty:Recipe'
-entry_points = {"zc.buildout": ["default = %s" % entry_point,
-                "Debug = mr.scripty:Debug"],}
+entry_points = {"zc.buildout": [
+    "default = %s" % entry_point,
+    "Debug = mr.scripty:Debug"]}
 
-tests_require = ['zope.testing', 'zc.buildout']
+tests_require = ['zope.testing', 'zc.buildout [test]']
 
 setup(name='mr.scripty',
       version=version,
@@ -45,11 +46,11 @@ setup(name='mr.scripty',
       # Get more strings from
       # http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
-        'Framework :: Buildout',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-        'License :: OSI Approved :: Zope Public License',
-        ],
+          'Framework :: Buildout',
+          'Intended Audience :: Developers',
+          'Topic :: Software Development :: Build Tools',
+          'License :: OSI Approved :: Zope Public License',
+      ],
       keywords='buildout',
       author='Dylan Jay',
       author_email='software@pretaweb.com',


### PR DESCRIPTION
Python 2.6 no longer works. Python 2.7 does work. I didn't found a way to make Python 2.6 work, but I no longer use it (only 2.7).